### PR TITLE
update to pytorch 1.13 and fix a misdescription

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ python styleTransfer.py --content_path PATH_TO_CONTENT_IMAGE --style_path PATH_T
 python styleTransfer.py --content_path PATH_TO_CONTENT_IMAGE --style_path PATH_TO_STYLE_IMAGE --output_path PATH_TO_OUTPUT --alpha ALPHA_VALUE
 ```
 
-(Optional Flag) Forbide augment style image with rotations. Speed up algorithm and decreases memory requirement. Generally hurts stylization slightly:  
+(Optional Flag) Disable augment style image with rotations. This optimization accelerates the algorithm and reduces memory usage, albeit resulting in a slight compromise in stylization quality:
 ```
 python styleTransfer.py --content_path PATH_TO_CONTENT_IMAGE --style_path PATH_TO_STYLE_IMAGE --output_path PATH_TO_OUTPUT --no_flip
 ```

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Try Replicate web demo here [![Replicate](https://replicate.com/nkolkin13/neural
 
 ## Dependencies
 Tested With:        
-* Python 3.7.7        
-* Pytorch 1.5.0       
-* Imageio 2.8.0        
-* Numpy 1.18.1          
+* Python 3.7.16        
+* Pytorch 1.13.1       
+* Imageio 2.31.1        
+* Numpy 1.21.6
 
 ## Example Output
 Example output produced using included files with the command:
@@ -50,9 +50,9 @@ python styleTransfer.py --content_path PATH_TO_CONTENT_IMAGE --style_path PATH_T
 python styleTransfer.py --content_path PATH_TO_CONTENT_IMAGE --style_path PATH_TO_STYLE_IMAGE --output_path PATH_TO_OUTPUT --alpha ALPHA_VALUE
 ```
 
-(Optional Flag) Augment style image with rotations. Slows down algorithm and increases memory requirement. Generally improves content preservation but hurts stylization slightly:  
+(Optional Flag) Forbide augment style image with rotations. Speed up algorithm and decreases memory requirement. Generally hurts stylization slightly:  
 ```
-python styleTransfer.py --content_path PATH_TO_CONTENT_IMAGE --style_path PATH_TO_STYLE_IMAGE --output_path PATH_TO_OUTPUT --do_flip
+python styleTransfer.py --content_path PATH_TO_CONTENT_IMAGE --style_path PATH_TO_STYLE_IMAGE --output_path PATH_TO_OUTPUT --no_flip
 ```
 
 (Optional Flag) Cpu Mode, this takes tens of minutes even for a 512x512 output:  

--- a/pretrained/vgg.py
+++ b/pretrained/vgg.py
@@ -14,14 +14,14 @@ class Vgg16Pretrained(torch.nn.Module):
         super(Vgg16Pretrained, self).__init__()
 
         try:
-            vgg_pretrained_features = models.vgg16(pretrained=True).features
+            vgg_pretrained_features = models.vgg16(weights='VGG16_Weights.DEFAULT').features
         except ssl.SSLError:
             # unsafe fix to allow pretrained pytorch model to be downloaded
             # exposes application to man-in-the-middle attacks while model is
             # being downloaded
             create_default_context = ssl._create_default_https_context
             ssl._create_default_https_context = ssl._create_unverified_context
-            vgg_pretrained_features = models.vgg16(pretrained=True).features
+            vgg_pretrained_features = models.vgg16(weights='VGG16_Weights.DEFAULT').features
             ssl._create_default_https_context = create_default_context
 
         self.vgg_layers = vgg_pretrained_features


### PR DESCRIPTION
I noticed that the command `do_flip` is not present in the original code, but `no_flip` is available, so I resolved this issue. 
Additionally, I have updated the code to be compatible with PyTorch version 1.13.